### PR TITLE
splash,cmd: update to handle units consistently

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"fmt"
+	"image/color"
+	"os"
+	"time"
+
 	"gioui.org/app"
 	"gioui.org/io/system"
 	"gioui.org/layout"
@@ -9,10 +13,6 @@ import (
 	"gioui.org/unit"
 	splash "github.com/gesellix/gioui-splash"
 	"github.com/gesellix/gioui-splash/assets"
-	"image"
-	"image/color"
-	"os"
-	"time"
 )
 
 func main() {
@@ -23,26 +23,23 @@ func main() {
 			os.Exit(0)
 		}
 		size := logo.Bounds().Size()
+		sizeXDp := unit.Dp(size.X)
+		sizeYDp := unit.Dp(size.Y)
 
 		options := []app.Option{
-			app.Size(unit.Dp(size.X), unit.Dp(size.Y)),
-			// see https://todo.sr.ht/~eliasnaur/gio/508
-			//app.Size(dpiAware.PxToDp(size.X), dpiAware.PxToDp(size.Y)),
+			app.Size(sizeXDp, sizeYDp),
+			app.MinSize(sizeXDp, sizeYDp),
+			app.MaxSize(sizeXDp, sizeYDp),
 			app.Title("Splash Example"),
 			app.Decorated(false),
 		}
 		w := app.NewWindow(options...)
-		//w := app.NewWindow()
-		//w.Option(options...)
 		w.Perform(system.ActionCenter)
-		//w.Perform(system.ActionRaise)
 
 		splashWidget := splash.NewSplash(
 			logo,
-			image.Rectangle{
-				Min: image.Pt(10, size.Y-10),
-				Max: image.Pt(size.X-10, size.Y-5),
-			},
+			5,  // Progress bar height is 5 Dp.
+			10, // Progress bar is inset 10 Dp from window edge.
 			color.NRGBA{R: 100, G: 200, B: 100, A: 42},
 		)
 		progress := 0.0
@@ -77,9 +74,6 @@ func main() {
 
 			case system.FrameEvent:
 				gtx := layout.NewContext(&ops, e)
-
-				//gtx.Constraints = layout.Exact(size)
-				//w.Option(app.Size(unit.Dp(size.X), unit.Dp(size.Y)))
 
 				splashDim := splashWidget.Layout(gtx)
 

--- a/splash.go
+++ b/splash.go
@@ -1,38 +1,57 @@
 package splash
 
 import (
+	"image"
+	"image/color"
+	"log"
+
 	"gioui.org/layout"
 	"gioui.org/op/clip"
 	"gioui.org/op/paint"
+	"gioui.org/unit"
 	"gioui.org/widget"
-	"image"
-	"image/color"
 )
 
 type Splash struct {
-	img          image.Image
-	progressRect image.Rectangle
-	progressCol  color.NRGBA
-	progress     float64
+	img            image.Image
+	progressHeight unit.Dp
+	progressCol    color.NRGBA
+	progress       float64
+	progressInset  layout.Inset
 }
 
-func NewSplash(img image.Image, progressRect image.Rectangle, progressCol color.NRGBA) *Splash {
+func NewSplash(img image.Image, progressHeight unit.Dp, progressInset unit.Dp, progressCol color.NRGBA) *Splash {
 	return &Splash{
 		img,
-		progressRect,
+		progressHeight,
 		progressCol,
 		0,
+		layout.UniformInset(progressInset),
 	}
 }
 
 func (s *Splash) SetProgress(progress float64) {
 	s.progress = progress
+	if s.progress > 1 {
+		s.progress = 1
+	}
+	if s.progress < 0 {
+		s.progress = 0
+	}
 }
 
 func (s *Splash) Layout(gtx layout.Context) layout.Dimensions {
-	dimensions := s.drawLogo(gtx)
-	s.drawProgress(gtx, s.progress)
-	return dimensions
+	// Lay out the image and overlay the progress bar on top of it, aligning
+	// to the south so that the progress bar is at the bottom.
+	return layout.Stack{
+		Alignment: layout.S,
+	}.Layout(gtx,
+		layout.Stacked(s.drawLogo),
+		layout.Expanded(func(gtx layout.Context) layout.Dimensions {
+			// Lay out the progress bar within the inset.
+			return s.progressInset.Layout(gtx, s.drawProgress)
+		}),
+	)
 }
 
 func (s *Splash) drawLogo(gtx layout.Context) layout.Dimensions {
@@ -42,17 +61,30 @@ func (s *Splash) drawLogo(gtx layout.Context) layout.Dimensions {
 	}.Layout(gtx)
 }
 
-func (s *Splash) drawProgress(gtx layout.Context, progress float64) {
-	spread := s.progressRect.Max.X - s.progressRect.Min.X
+func (s *Splash) drawProgress(gtx layout.Context) layout.Dimensions {
+	// Our gtx.Constraints.Min.X provide the width that a full progress bar
+	// must occupy.
+	spread := gtx.Constraints.Min.X
 	rectangle := image.Rectangle{
-		Min: s.progressRect.Min,
 		Max: image.Pt(
-			s.progressRect.Min.X+int(progress*float64(spread)),
-			s.progressRect.Max.Y,
+			// Since spread is already a unit of screen pixels, no need to pass through gtx.Dp
+			// to convert to them.
+			int(float64(spread)*s.progress),
+			// Convert our progress bar height to screen pixels.
+			gtx.Dp(s.progressHeight),
 		),
 	}
+	log.Printf("spread: %v progress: %v minX: %v", spread, s.progress, gtx.Constraints.Min.X)
 	paint.FillShape(
 		gtx.Ops,
 		s.progressCol,
 		clip.Rect(rectangle).Op())
+	// Return the logical dimensions occupied by the progress bar, which is the width of a full
+	// bar.
+	return layout.Dimensions{
+		Size: image.Point{
+			X: gtx.Constraints.Min.X,
+			Y: gtx.Dp(s.progressHeight),
+		},
+	}
 }


### PR DESCRIPTION
This commit fixes a unit mixup that caused confusion. Previously the main program was responsible for providing a rectangle, and this rectangle was used as the bounding box of the progress bar. However, this rectangle was in screen pixels, and thus wasn't being scaled using gtx.Dp. It would be the same number of physical pixels no matter the system scaling factor.

This commit restructures the splash widget to accept the height and inset of the progress bar in Dp, and the splash widget itself handles converting these to screen pixels during layout. Delaying this unit conversion until the point of layout ensures that even if the window changes scaling factors, the UI will respond appropriately on the next frame.

I dedicate the contents of this PR to the public domain under the terms of the UNLICENSE or CC0. They may also be used under the terms of the MIT license.